### PR TITLE
feat: remove device when entry deleted

### DIFF
--- a/tests/test_remove_entry_device.py
+++ b/tests/test_remove_entry_device.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.sok import async_remove_config_entry_device
+from custom_components.sok.const import DOMAIN
+
+
+class DummyHass:
+    pass
+
+
+class DummyRegistry:
+    def __init__(self):
+        self.removed = None
+
+    def async_remove_device(self, device_id: str) -> None:
+        self.removed = device_id
+
+
+@pytest.mark.asyncio
+async def test_remove_config_entry_device(monkeypatch):
+    hass = DummyHass()
+    entry = SimpleNamespace(unique_id="00:11:22:33:44:55")
+    registry = DummyRegistry()
+    monkeypatch.setattr("custom_components.sok.dr.async_get", lambda _: registry)
+    device = SimpleNamespace(
+        id="device1", identifiers={(DOMAIN, "00:11:22:33:44:55")}
+    )
+
+    result = await async_remove_config_entry_device(hass, entry, device)
+
+    assert result is True
+    assert registry.removed == "device1"


### PR DESCRIPTION
## Summary
- support removing devices when HA deletes the entry
- add regression test for device removal

## Testing
- `./.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684648921bb4832eb834e255e5ff8f12