### PR TITLE
Add detailed logging

### DIFF
--- a/custom_components/sok/__init__.py
+++ b/custom_components/sok/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+import logging
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -10,6 +11,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 from .coordinator import SOKDataUpdateCoordinator
 
@@ -21,6 +24,8 @@ PLATFORMS: list[Platform] = [Platform.SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: SOKConfigEntry) -> bool:
     """Set up SOK BLE device from a config entry."""
     assert entry.unique_id is not None
+    battery_name = getattr(entry, "title", entry.unique_id)
+    _LOGGER.debug("Setting up SOK battery %s", battery_name)
     coordinator = SOKDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
@@ -30,6 +35,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SOKConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: SOKConfigEntry) -> bool:
     """Unload a config entry."""
+    battery_name = getattr(entry, "title", entry.unique_id)
+    _LOGGER.debug("Unloading SOK battery %s", battery_name)
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         coordinator: SOKDataUpdateCoordinator = entry.runtime_data


### PR DESCRIPTION
## Summary
- add more debug logging to coordinator
- log when entries load/unload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bleak')*

------
https://chatgpt.com/codex/tasks/task_e_684714851d74832e9102fb939893b8a3