### PR TITLE
Adjust voltage sensor precision

### DIFF
--- a/custom_components/sok/sensor.py
+++ b/custom_components/sok/sensor.py
@@ -51,6 +51,7 @@ SENSOR_DESCRIPTIONS: tuple[SokSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda dev: dev.voltage,
     ),
     SokSensorEntityDescription(
@@ -103,6 +104,7 @@ SENSOR_DESCRIPTIONS: tuple[SokSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda dev: dev.cell_voltages[0] if dev.cell_voltages else None,
     ),
     SokSensorEntityDescription(
@@ -111,6 +113,7 @@ SENSOR_DESCRIPTIONS: tuple[SokSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda dev: dev.cell_voltages[1] if dev.cell_voltages else None,
     ),
     SokSensorEntityDescription(
@@ -119,6 +122,7 @@ SENSOR_DESCRIPTIONS: tuple[SokSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda dev: dev.cell_voltages[2] if dev.cell_voltages else None,
     ),
     SokSensorEntityDescription(
@@ -127,6 +131,7 @@ SENSOR_DESCRIPTIONS: tuple[SokSensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.VOLTAGE,
         native_unit_of_measurement=UnitOfElectricPotential.VOLT,
         state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=2,
         value_fn=lambda dev: dev.cell_voltages[3] if dev.cell_voltages else None,
     ),
 )

--- a/tests/test_sensor_descriptions.py
+++ b/tests/test_sensor_descriptions.py
@@ -23,3 +23,17 @@ def test_sensor_descriptions_value():
     for desc in SENSOR_DESCRIPTIONS:
         # Each sensor description should return a value without error
         assert desc.value_fn(device) is not None
+
+
+def test_voltage_sensor_precision():
+    voltage_keys = {
+        "voltage",
+        "cell_1_voltage",
+        "cell_2_voltage",
+        "cell_3_voltage",
+        "cell_4_voltage",
+    }
+
+    for desc in SENSOR_DESCRIPTIONS:
+        if desc.key in voltage_keys:
+            assert desc.suggested_display_precision == 2


### PR DESCRIPTION
## Summary
- show voltages with two decimal points
- test precision settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3e9ef85c832e86ef4a459cddea65