### PR TITLE
Fix tests for updated SOK Battery domain

### DIFF
--- a/custom_components/sok_battery/const.py
+++ b/custom_components/sok_battery/const.py
@@ -1,3 +1,3 @@
 """Constants for the SOK Bluetooth integration."""
 
-DOMAIN = "sok"
+DOMAIN = "sok_battery"

--- a/tests/test_cell_sensors.py
+++ b/tests/test_cell_sensors.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from custom_components.sok.sensor import SENSOR_DESCRIPTIONS
+from custom_components.sok_battery.sensor import SENSOR_DESCRIPTIONS
 
 
 def test_cell_sensor_values():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import pytest
 from bleak.backends.device import BLEDevice
 
-from custom_components.sok.coordinator import SOKDataUpdateCoordinator
+from custom_components.sok_battery.coordinator import SOKDataUpdateCoordinator
 
 
 class DummyHass:
@@ -33,7 +33,7 @@ async def test_async_update(monkeypatch):
         self.cell_voltages = [3.3, 3.3, 3.3, 3.3]
 
     monkeypatch.setattr(
-        "custom_components.sok.coordinator.async_ble_device_from_address",
+        "custom_components.sok_battery.coordinator.async_ble_device_from_address",
         fake_ble_device_from_address,
     )
     monkeypatch.setattr(

--- a/tests/test_energy_sensors.py
+++ b/tests/test_energy_sensors.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from custom_components.sok.sensor import SOKEnergySensor
+from custom_components.sok_battery.sensor import SOKEnergySensor
 from homeassistant.util import dt as dt_util
 
 

--- a/tests/test_remove_entry_device.py
+++ b/tests/test_remove_entry_device.py
@@ -2,8 +2,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from custom_components.sok import async_remove_config_entry_device
-from custom_components.sok.const import DOMAIN
+from custom_components.sok_battery import async_remove_config_entry_device
+from custom_components.sok_battery.const import DOMAIN
 
 
 class DummyHass:
@@ -23,7 +23,9 @@ async def test_remove_config_entry_device(monkeypatch):
     hass = DummyHass()
     entry = SimpleNamespace(unique_id="00:11:22:33:44:55")
     registry = DummyRegistry()
-    monkeypatch.setattr("custom_components.sok.dr.async_get", lambda _: registry)
+    monkeypatch.setattr(
+        "custom_components.sok_battery.dr.async_get", lambda _: registry
+    )
     device = SimpleNamespace(
         id="device1", identifiers={(DOMAIN, "00:11:22:33:44:55")}
     )

--- a/tests/test_sensor_descriptions.py
+++ b/tests/test_sensor_descriptions.py
@@ -1,6 +1,6 @@
 from types import SimpleNamespace
 
-from custom_components.sok.sensor import SENSOR_DESCRIPTIONS
+from custom_components.sok_battery.sensor import SENSOR_DESCRIPTIONS
 
 class DummyCoordinator:
     def __init__(self, device):

--- a/tests/test_sensor_no_data.py
+++ b/tests/test_sensor_no_data.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from custom_components.sok.sensor import SOKSensorEntity, SENSOR_DESCRIPTIONS
+from custom_components.sok_battery.sensor import SOKSensorEntity, SENSOR_DESCRIPTIONS
 
 class DummyCoordinator:
     def __init__(self, data=None):


### PR DESCRIPTION
## Summary
- update const DOMAIN to `sok_battery`
- fix all tests to import from `custom_components.sok_battery`
- patch monkeypatch references to new module path

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8d6f1538832e9d61948c21d218a2